### PR TITLE
Updated NewAction.php action interface

### DIFF
--- a/Controller/Subscriber/NewAction.php
+++ b/Controller/Subscriber/NewAction.php
@@ -5,7 +5,7 @@ use Magento\Customer\Api\AccountManagementInterface as CustomerAccountManagement
 use Magento\Customer\Model\Session;
 use Magento\Customer\Model\Url as CustomerUrl;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Newsletter\Model\SubscriberFactory;
 use Magento\Framework\Data\Form\FormKey\Validator;
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class NewAction extends \Magento\Newsletter\Controller\Subscriber implements HttpGetActionInterface
+class NewAction extends \Magento\Newsletter\Controller\Subscriber implements HttpPostActionInterface
 {
     /**
      * @var CustomerAccountManagement


### PR DESCRIPTION
Since your newsletter template is using post (as it should) your controller should implement the HttpPostActionInterface and not the HttpGetActionInterface. As it is now, submitting the form causes a 404. 

Tested on 2.3.5-p2 and 2.4.2-p2.

Your readme says: `Tested up to Magento 2.4.2`, are you really sure about that :)