### PR TITLE
Fix: ValidationError when sending transactional emails with empty recipient/sender names

### DIFF
--- a/Model/Api/Transaction.php
+++ b/Model/Api/Transaction.php
@@ -2,12 +2,14 @@
 
 namespace Rule\RuleMailer\Model\Api;
 
-use Rule\ApiWrapper\ApiFactory;
-use Rule\ApiWrapper\Api\Api;
 use Magento\Framework\Mail\Address;
-use Magento\Framework\Mail\MessageInterface;
-use Magento\Framework\Mail\MailMessageInterface;
+use Magento\Framework\Mail\EmailMessage;
 use Magento\Framework\Mail\EmailMessageInterface;
+use Magento\Framework\Mail\MailMessageInterface;
+use Magento\Framework\Mail\MessageInterface;
+use Rule\ApiWrapper\Api\Api;
+use Rule\ApiWrapper\Api\Exception\InvalidResourceException;
+use Rule\ApiWrapper\ApiFactory;
 
 /**
  * Class Transaction holds transaction during API calls
@@ -22,7 +24,7 @@ class Transaction
     /**
      * Transaction constructor.
      * @param $apiKey
-     * @throws \Rule\ApiWrapper\Api\Exception\InvalidResourceException
+     * @throws InvalidResourceException
      * @SuppressWarnings(PHPMD.StaticAccess)
      */
     public function __construct($apiKey)
@@ -31,7 +33,15 @@ class Transaction
     }
 
     /**
+     * Send email message via Rule Transactional API
+     *
+     * Note: The 'name' field is only included in from/to arrays when not empty,
+     * as the Rule API requires name to be a non-empty string when present.
+     * This handles cases where Magento's Address::getName() returns null.
+     *
      * @param MessageInterface|MailMessageInterface|EmailMessageInterface $message
+     *
+     * @return void
      * @see https://apidoc.rule.se/#transactions-send-transaction
      */
     public function sendMessage($message)
@@ -39,26 +49,33 @@ class Transaction
         $transaction = [];
 
         if ($message instanceof EmailMessageInterface) {
-            /** @var \Magento\Framework\Mail\EmailMessage $message */
+            /** @var EmailMessage $message */
 
             $from = $message->getFrom();
             $from1 = array_shift($from);
 
             $recipients = $message->getTo();
             foreach ($recipients as $recipient) {
-                /** @var Address $item */
+                /** @var Address $recipient */
+                $recipientName = $recipient->getName();
+                $fromName = $from1->getName();
+                $fromArray = ['email' => $from1->getEmail()];
+
+                if (!empty($fromName)) {
+                    $fromArray['name'] = $fromName;
+                }
+
+                $toArray = ['email' => $recipient->getEmail()];
+                if (!empty($recipientName)) {
+                    $toArray['name'] = $recipientName;
+                }
+
                 $transaction = [
                     'transaction_type' => 'email',
                     'transaction_name' => 'some',
                     'subject' => $message->getSubject(),
-                    'from' => [
-                        'name' => $from1->getName(),
-                        'email' => $from1->getEmail()
-                    ],
-                    'to' => [
-                        'name' => $recipient->getName(),
-                        'email' => $recipient->getEmail()
-                    ],
+                    'from' => $fromArray,
+                    'to' => $toArray,
                     'content' => [
                         'plain' => quoted_printable_decode($message->getBodyText()),
                         'html' => quoted_printable_decode($message->getBodyText())
@@ -77,3 +94,4 @@ class Transaction
         $this->transactionApi->send($transaction);
     }
 }
+

--- a/Model/Api/Transaction.php
+++ b/Model/Api/Transaction.php
@@ -51,31 +51,30 @@ class Transaction
         if ($message instanceof EmailMessageInterface) {
             /** @var EmailMessage $message */
 
-            $from = $message->getFrom();
-            $from1 = array_shift($from);
+            $sender = $message->getFrom()[0];
+            $senderName = $sender->getName();
+
+            $from = ['email' => $sender->getEmail()];
+            if (!empty($senderName)) {
+                $from['name'] = $senderName;
+            }
 
             $recipients = $message->getTo();
             foreach ($recipients as $recipient) {
                 /** @var Address $recipient */
                 $recipientName = $recipient->getName();
-                $fromName = $from1->getName();
-                $fromArray = ['email' => $from1->getEmail()];
 
-                if (!empty($fromName)) {
-                    $fromArray['name'] = $fromName;
-                }
-
-                $toArray = ['email' => $recipient->getEmail()];
+                $to = ['email' => $recipient->getEmail()];
                 if (!empty($recipientName)) {
-                    $toArray['name'] = $recipientName;
+                    $to['name'] = $recipientName;
                 }
 
                 $transaction = [
                     'transaction_type' => 'email',
                     'transaction_name' => 'some',
                     'subject' => $message->getSubject(),
-                    'from' => $fromArray,
-                    'to' => $toArray,
+                    'from' => $from,
+                    'to' => $to,
                     'content' => [
                         'plain' => quoted_printable_decode($message->getBodyText()),
                         'html' => quoted_printable_decode($message->getBodyText())
@@ -94,4 +93,3 @@ class Transaction
         $this->transactionApi->send($transaction);
     }
 }
-


### PR DESCRIPTION
### Problem
When attempting to send transactional emails via the Rule API, the module throws a fatal error:
```
Fatal error: Uncaught Error: Wrong parameters for Rule\ApiWrapper\Api\Exception\ResponseErrorException
```
With the underlying validation error:
```php
Array (
    [error] => ValidationError
    [message] => Array (
        [to.name] => Array (
            [0] => The to.name must be a string.
        )
    )
)
```

### Root cause
The issue occurs in `Model/Api/Transaction.php` when building the transaction payload for the Rule API.

Magento's `\Magento\Framework\Mail\Address::getName()` method has a return type of `?string` (nullable string), meaning it can legitimately return `null` when no name is provided. This occurs with newsletter subscriptions where only an email address is collected.

The original code always included the `name` field in both `from` and `to` arrays, even when the value was `null`:
```php
$transaction = [
    'from' => [
        'name' => $from1->getName(),  // Can be null
        'email' => $from1->getEmail()
    ],
    'to' => [
        'name' => $recipient->getName(),  // Can be null
        'email' => $recipient->getEmail()
    ],
    // ...
];
```

When `getName()` returns `null`, the Rule API receives:
```php
'to' => ['name' => null, 'email' => 'user@email.com']
```
The Rule Transactional API validates that if the `name` field is present, it must be a non-empty string. Sending `null` or an empty string fails this validation.

### Solution
The fix conditionally includes the `name` field only when it contains a non-empty value:
```php
// Build from array
$fromArray = ['email' => $from1->getEmail()];
if (!empty($fromName)) {
    $fromArray['name'] = $fromName;
}

// Build to array
$toArray = ['email' => $recipient->getEmail()];
if (!empty($recipientName)) {
    $toArray['name'] = $recipientName;
}
```

This way:
* When a name is available: `['name' => 'John Doe', 'email' => 'john@email.com']`
* When no name is available: `['email' => 'john@email.com']` (name field omitted entirely)

The Rule API accepts both formats, but requires `name` to be a non-empty string when present.

### Compatibility
**Bug replicated on:**
* Magento Commerce 2.3.7-p2
* Magento Community 2.4.8-p3

**Fix verified on:**
* Magento Commerce 2.3.7-p2
* Magento Community 2.4.8-p3

All transactional emails (newsletter subscriptions, order confirmations, password change request etc.) now send successfully without validation errors.

**Edit/Note:** Use statements have been reorganized alphabetically to follow PSR-12 conventions.